### PR TITLE
문제점을 개선한 사항들입니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 npm-debug.log
 source/libs/noto-sans-kr
 source/libs/spoqa-han-sans
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The Overdose is minimalistic, simple and beatiful hexo theme, specialized in Korean blogs.
 
-This theme works with hexo v3.2 or later.
+This theme works with hexo v3.2 or later and Node v7 or lower.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,9 @@ The overdose theme is using jade/sass(with bourbon). So install renderers.
 $ npm install --save hexo-renderer-jade hexo-renderer-bourbon
 ```
 
-And clone vendor repositories.
+And initialize this theme.
 ```
-$ cd themes/overdose;npm run clone
-```
-
-Then, copy the configuration example file.
-```
-$ cp _config.yml.example _config.yml
+$ cd themes/overdose;node init
 ```
 
 And then, specify `overdose` theme in your root configuration file.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This theme works with hexo v3.2 or later and Node v7 or lower.
 - Responsive design
 - Lightweight, not using jQuery or underscore.js, etc.
 - Various code highlighting theme (Thanks to @SungYeolWoo), Set [Dracula](https://draculatheme.com/) theme by default
-- Font setting
+- [Font setting](#font-setting)
   - noto-sans-kr
   - spoqa-han-sans-kr
   - spoqa-han-sans-jp
@@ -61,6 +61,44 @@ theme: overdose
 Finally, start the hexo server and enjoy.
 ```
 $ hexo server
+```
+
+### Font setting
+You could choose from the following options.  
+After install, you should set font config in themes/overdose/_config.yml
+```yaml
+# Font
+## availableFontList: [
+##   'noto-sans-kr',
+##   'spoqa-han-sans-kr',
+##   'spoqa-han-sans-jp'
+## ]
+## If you don't want font, you shouldn't specify the font.
+font:
+```
+* noto-sans-kr
+```bash
+npm run noto-kr
+```
+* spoqa-han-sans-kr
+```bash
+npm run spo-kr
+```
+* spoqa-han-sans-jp
+```bash
+npm run spo-jp
+```
+* Korean fonts(noto-sans-kr, spoqa-han-sans-kr)
+```bash
+npm run font-kr
+```
+* Spoqa fonts(spoqa-han-sans-kr, spoqa-han-sans-jp)
+```bash
+npm run spoqa
+```
+* All fonts(noto-sans-kr, spoqa-han-sans-kr, spoqa-han-sans-jp)
+```bash
+npm run font
 ```
 
 ### Configuration

--- a/init.js
+++ b/init.js
@@ -1,0 +1,9 @@
+var fs = require('fs');
+var path = require('path');
+var deleteFolderRecursive = require('./util').deleteFolderRecursive;
+var input = path.resolve(__dirname, '_config.yml.example');
+var output = path.resolve(__dirname, '_config.yml');
+
+fs.createReadStream(input).pipe(fs.createWriteStream(output));
+deleteFolderRecursive(path.resolve(__dirname, '.git'));
+fs.unlink(path.resolve(__dirname, '.gitignore'));

--- a/layout/includes/head.jade
+++ b/layout/includes/head.jade
@@ -24,9 +24,9 @@ meta(name="viewport" content="width=device-width, initial-scale=1, maximum-scale
 title= pageTitle
 
 if theme.font === 'spoqa-han-sans-kr'
-  link(rel="stylesheet" href="/libs/spoqa-han-sans/css/SpoqaHanSans-kr.css")
+  link(rel="stylesheet" href="/libs/spoqa-han-sans-kr/css/SpoqaHanSans-kr.css")
 else if theme.font === 'spoqa-han-sans-jp'
-  link(rel="stylesheet" href="/libs/spoqa-han-sans/css/SpoqaHanSans-jp.css")
+  link(rel="stylesheet" href="/libs/spoqa-han-sans-jp/css/SpoqaHanSans-jp.css")
 else if theme.font === 'noto-sans-kr'
   link(rel="stylesheet" href="/libs/noto-sans-kr/styles.css")
   

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "The theme which you must be overdosed.",
   "private": true,
   "scripts": {
-    "font": "npm run noto && npm run spo",
-    "font-kr": "git clone https://github.com/hyunseob/noto-sans-kr ./source/libs/noto-sans-kr && git clone https://github.com/perfectacle/spoqa-han-sans-kr ./source/libs/spoqa-han-sans-kr && node rm-git",
-    "spo": "git clone https://github.com/perfectacle/spoqa-han-sans-kr ./source/libs/spoqa-han-sans-kr && git clone https://github.com/perfectacle/spoqa-han-sans-jp ./source/libs/spoqa-han-sans-jp && node rm-git",
+    "font": "npm run noto-kr && npm run spo",
+    "font-kr": "npm run noto-kr && npm run spo",
+    "spo": "npm run spo-kr && npm run spo-jp",
     "noto-kr": "git clone https://github.com/hyunseob/noto-sans-kr ./source/libs/noto-sans-kr && node rm-git",
     "spo-kr": "git clone https://github.com/perfectacle/spoqa-han-sans-kr ./source/libs/spoqa-han-sans-kr && node rm-git",
     "spo-jp": "git clone https://github.com/perfectacle/spoqa-han-sans-jp ./source/libs/spoqa-han-sans-jp && node rm-git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "description": "The theme which you must be overdosed.",
   "private": true,
   "scripts": {
-    "clone": "git clone https://github.com/spoqa/spoqa-han-sans ./source/libs/spoqa-han-sans;git clone https://github.com/hyunseob/noto-sans-kr ./source/libs/noto-sans-kr",
+    "font": "npm run noto && npm run spo",
+    "font-kr": "git clone https://github.com/hyunseob/noto-sans-kr ./source/libs/noto-sans-kr && git clone https://github.com/perfectacle/spoqa-han-sans-kr ./source/libs/spoqa-han-sans-kr && node rm-git",
+    "spo": "git clone https://github.com/perfectacle/spoqa-han-sans-kr ./source/libs/spoqa-han-sans-kr && git clone https://github.com/perfectacle/spoqa-han-sans-jp ./source/libs/spoqa-han-sans-jp && node rm-git",
+    "noto-kr": "git clone https://github.com/hyunseob/noto-sans-kr ./source/libs/noto-sans-kr && node rm-git",
+    "spo-kr": "git clone https://github.com/perfectacle/spoqa-han-sans-kr ./source/libs/spoqa-han-sans-kr && node rm-git",
+    "spo-jp": "git clone https://github.com/perfectacle/spoqa-han-sans-jp ./source/libs/spoqa-han-sans-jp && node rm-git",
     "build": "node_modules/.bin/uglifyjs ./source/js/dynamicMenu.js -m -o ./source/js/dynamicMenu.min.js;node_modules/.bin/uglifyjs ./source/js/sharer.js -m -o ./source/js/sharer.min.js;cat ./source/js/dynamicMenu.min.js ./source/js/sharer.min.js > ./source/js/index.min.js"
   },
   "dependencies": {},

--- a/rm-git.js
+++ b/rm-git.js
@@ -1,0 +1,14 @@
+var fs = require('fs');
+var path = require('path');
+var libsPath = path.resolve(__dirname, 'source', 'libs');
+var delPaths = [
+  path.resolve(libsPath, 'noto-sans-kr', '.git'),
+  path.resolve(libsPath, 'spoqa-han-sans-kr', '.git'),
+  path.resolve(libsPath, 'spoqa-han-sans-jp', '.git')
+];
+var deleteFolderRecursive = require('./util').deleteFolderRecursive;
+
+delPaths.forEach(function(path) {
+  deleteFolderRecursive(path);
+});
+

--- a/util.js
+++ b/util.js
@@ -1,0 +1,15 @@
+var fs = require('fs');
+
+exports.deleteFolderRecursive = deleteFolderRecursive = function(path) {
+  if(fs.existsSync(path)) {
+    fs.readdirSync(path).forEach(function(file) {
+      var curPath = path + '/' + file;
+      if(fs.lstatSync(curPath).isDirectory()) { // recurse
+        deleteFolderRecursive(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(path);
+  }
+};


### PR DESCRIPTION
1. IntelliJ IDE를 위해 .gitignore에 파일을 추가하였습니다.

2. Node v8에서는 사용이 불가능하단 문구를 추가했습니다.
hexo-renderer-bourbon v1.0.4가 Node v7까지만 작동하는 걸 확인했습니다.

3. git clone 받은 저장소(overdose 테마, 폰트들)은 나중에 github에 push하면 올라가지 않는다는 단점이 존재합니다. [이 저장소](https://github.com/perfectacle/test-blog3/tree/master/themes)의 hueman과 같은 테마와 같이 저런 식으로 폴더들이 안 올라가는 문제들이 존재하더라구요(overdose 테마나 noto-sans-kr 폴더 등등도 .git 폴더를 삭제하지 않으면 마찬가지더라구요.)
clone 받은 디렉토리 내의 .git 폴더 때문에 그러더라구요. 그리고 유저들이 수정한 _config.yml이나 유저가 받은 폰트 파일들이 .gitignore 파일에 존재해서 유저들이 나중에 자신의 깃헙 페이지를 클론하면 다시 수정하고 폰트도 다시 명령어를 입력해서 클론해야한다는 단점도 존재하더라구요. 그래서 init.js 파일을 실행시켜서 .git 디렉토리와 .gitignore 파일을 삭제하게 끔 했습니다. 명령어로 처리하려고 하니 Mac 사용자와 Windows 사용자 등등을 아우르기 힘들어서 그냥 Node에서 실행하게 끔 했습니다.

4. 기존에는 npm run clone으로 폰트들을 일괄적으로 받을 수 있었습니다. 하지만 spoqa-han-sans 저장소를 전부 클론하다보니 폰트 개발자나 알고 있어야하는 파일들까지 다 받아서 수 백 메가에 달하는 파일들을 받아야했습니다. 또한 일괄적으로 받다보니 일본어 폰트라던지 쓰지도 않는 폰트도 받아야하는 문제가 발생했습니다. 이를 위해 폰트의 개별 다운로드를 받는 npm script를 작성했고, spoqa-han-sans의 경우에는 웹폰트와 관련된 파일만 따로 뺀 경량화 한 저장소를 만들어 그 저장소를 클론하게끔 만들었습니다. 그리고 위에 기술한 바와 같이 git repository를 클론 받은 거다 보니 그 내부에는 .git 디렉토리가 존재해서 github에 push해도 올라가지 않는 문제가 발생했습니다. 이를 위해 폰트 디렉토리 내부의 .git 디렉토리들을 삭제하는 rm-git.js를 만들어 폰트 파일 클론 이후에 .git 디렉토리 파일을 제거하게 끔 하였습니다.