### PR TITLE
Make articles dates conform to date format specified in the main config file

### DIFF
--- a/layout/includes/article.pug
+++ b/layout/includes/article.pug
@@ -4,7 +4,7 @@ article#article.article(itemscope itemtype="https://schema.org/BlogPosting")
     time.article__meta__time(
       datetime=date_xml(page.date)
       itemprop="datePublished"
-    )= full_date(page.date)
+    )= full_date(page.date, config.date_format)
     if page.categories && page.categories.length
       .article__meta__categories
         each category, index in page.categories.data


### PR DESCRIPTION
Dates now use the format set up in the site's config